### PR TITLE
Optionalize mockStore's second argument

### DIFF
--- a/packages/testing/src/mockStore.ts
+++ b/packages/testing/src/mockStore.ts
@@ -13,7 +13,7 @@ export interface MockStore {
 
 export const mockStore = <S extends StoreClass>(
   StoreClass: S,
-  partialState: Partial<ExtractStateType<S>>,
+  partialState: Partial<ExtractStateType<S>> = {},
 ): MockStore => {
   const store = new StoreClass(mockStoreContext())
   Object.assign((store as any).state, partialState)


### PR DESCRIPTION
Storeの初期状態がinitialStateFactory以外で決まるの普通にややこしいから推奨したくない