### PR TITLE
Update to use function custom `App` in create-fleur-next-app template

### DIFF
--- a/packages/create-fleur-next-app/template/lib/fleur.tsx
+++ b/packages/create-fleur-next-app/template/lib/fleur.tsx
@@ -1,4 +1,4 @@
-import { AppContext, AppProps, AppInitialProps } from 'next/app'
+import NextApp, { AppContext, AppProps, AppInitialProps } from 'next/app'
 import { FleurContext } from '@fleur/react'
 import { useMemo } from 'react'
 import {
@@ -22,12 +22,16 @@ export const getOrCreateFleurContext = (state: any = null) => {
 
 export type FleurAppContext = AppContext & { ctx: PageContext }
 
+declare class ClassApp extends NextApp {
+  static getInitialProps(appContext: FleurAppContext): Promise<AppInitialProps>
+}
+
 interface FunctionApp {
   (props: AppProps): JSX.Element
   getInitialProps(appContext: FleurAppContext): Promise<AppInitialProps>
 }
 
-export const appWithFleurContext = (App: FunctionApp) => {
+export const appWithFleurContext = (App: typeof ClassApp | FunctionApp) => {
   const Comp = ({ __FLEUR_STATE__, ...props }: any) => {
     const fleurContext = useMemo(
       () => getOrCreateFleurContext(deserializeContext(__FLEUR_STATE__)),

--- a/packages/create-fleur-next-app/template/lib/fleur.tsx
+++ b/packages/create-fleur-next-app/template/lib/fleur.tsx
@@ -1,10 +1,11 @@
-import { default as NextApp } from 'next/app'
+import { AppContext, AppProps, AppInitialProps } from 'next/app'
 import { FleurContext } from '@fleur/react'
 import { useMemo } from 'react'
 import {
   bindFleurContext,
   serializeContext,
   deserializeContext,
+  PageContext,
 } from '@fleur/next'
 import { createContext } from '../domains'
 
@@ -19,7 +20,14 @@ export const getOrCreateFleurContext = (state: any = null) => {
   return context
 }
 
-export const appWithFleurContext = (App: typeof NextApp) => {
+export type FleurAppContext = AppContext & { ctx: PageContext }
+
+interface FunctionApp {
+  (props: AppProps): JSX.Element
+  getInitialProps(appContext: FleurAppContext): Promise<AppInitialProps>
+}
+
+export const appWithFleurContext = (App: FunctionApp) => {
   const Comp = ({ __FLEUR_STATE__, ...props }: any) => {
     const fleurContext = useMemo(
       () => getOrCreateFleurContext(deserializeContext(__FLEUR_STATE__)),

--- a/packages/create-fleur-next-app/template/pages/_app.tsx
+++ b/packages/create-fleur-next-app/template/pages/_app.tsx
@@ -1,4 +1,15 @@
-import App from 'next/app'
-import { appWithFleurContext } from '../lib/fleur'
+import App, { AppProps } from 'next/app'
+import { appWithFleurContext, FleurAppContext } from '../lib/fleur'
 
-export default appWithFleurContext(class MyApp extends App {})
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}
+
+MyApp.getInitialProps = async (appContext: FleurAppContext) => {
+  // calls page's `getInitialProps` and fills `appProps.pageProps`
+  const appProps = await App.getInitialProps(appContext)
+
+  return { ...appProps }
+}
+
+export default appWithFleurContext(MyApp)


### PR DESCRIPTION
Update to use function custom `App` in create-fleur-next-app template, to match new Next.js document.

FYI: https://nextjs.org/docs/advanced-features/custom-app