### PR TITLE
Fix un-proxied context methods

### DIFF
--- a/packages/fleur/src/AppContext.ts
+++ b/packages/fleur/src/AppContext.ts
@@ -40,19 +40,32 @@ export class AppContext {
     this.dispatch = this.dispatch.bind(this)
     this.depend = this.depend.bind(this)
 
+    const self = this
     this.operationContext = {
-      executeOperation: this.executeOperation,
-      dispatch: this.dispatch,
-      getStore: this.getStore,
-      depend: this.depend,
+      get executeOperation() {
+        return self.executeOperation
+      },
+      get dispatch() {
+        return self.dispatch
+      },
+      get getStore() {
+        return self.getStore
+      },
+      get depend() {
+        return self.depend
+      },
     }
 
     this.componentContext = {
       executeOperation: (op, ...args) => {
-        this.executeOperation(op, ...args)
+        self.executeOperation(op, ...args)
       },
-      getStore: this.getStore,
-      depend: this.depend,
+      get getStore() {
+        return self.getStore
+      },
+      get depend() {
+        return self.depend
+      },
     }
   }
 

--- a/packages/fleur/src/withReduxDevtools.ts
+++ b/packages/fleur/src/withReduxDevtools.ts
@@ -37,11 +37,8 @@ export const withReduxDevTools = (
     context.stores.forEach(store => store.emitChange())
   })
 
-  const dispatch = context.dispatch.bind(context)
-  context.dispatch = context.operationContext.dispatch = (
-    actionIdentifier: any,
-    payload: any,
-  ) => {
+  const dispatch = context.dispatch
+  context.dispatch = (actionIdentifier: any, payload: any) => {
     dispatch(actionIdentifier, payload)
     devTools.send(
       { type: actionIdentifier.name, payload },


### PR DESCRIPTION
- https://github.com/fleur-js/fleur/pull/179 で意図せず<なんとか>Contextのメソッドの参照先を変えてしまっていた
  - middlewareを差し込むときの「AppContextのメソッドだけをオーバーライドすればよい」を破壊していた