### PR TITLE
Fix returning old select value when changes mapStoresToProps

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 4.0.1
+
+- ❗important BugFix❗ [#314](https://github.com/fleur-js/fleur/pull/314) Fix returning old select value when changes mapStoresToProps
+
+Fixed it!
+
+```ts
+// Let userId is "1" in first rendering, "2" in next rendering
+const { userId } = useParams()
+
+// Expect to return user(id: 1) in first rendering, it works correctly
+// 💥WTF💥 Expect to return user(id: 2) in next rendering, but returns user(id: 1)
+const user = useStore(getStore => UserSelector.byId(getStore, userId))
+```
+
 ### 4.0.0
 
 - [#183](https://github.com/fleur-js/fleur/pull/183) in v3.3.0 was breaking change for component update rule. So bump major version.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleur/react",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": "https://github.com/fleur-js/fleur/tree/master/packages/react",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/react/src/useStore.spec.ts
+++ b/packages/react/src/useStore.spec.ts
@@ -22,8 +22,15 @@ describe('useStore', () => {
   })
 
   // Store
-  const TestStore = reducerStore<{ count: number }>('TestStore', () => ({
+  const TestStore = reducerStore<{
+    count: number
+    entities: Record<string, string>
+  }>('TestStore', () => ({
     count: 10,
+    entities: {
+      '1': 'Foo',
+      '2': 'Bar',
+    },
   })).listen(ident, (draft, { increase }) => (draft.count += increase))
 
   const Test2Store = reducerStore('Test2Store', () => ({ test2: 'hi' }))
@@ -61,6 +68,24 @@ describe('useStore', () => {
     })
 
     expect(result.current).toMatchObject({ count: 20 })
+    unmount()
+  })
+
+  it('Should map stores to state with variable selector', async () => {
+    const context = app.createContext()
+
+    let index: string = '1'
+    const { result, rerender, unmount } = renderHook(
+      () => useStore(getStore => getStore(TestStore).state.entities[index]),
+      { wrapper: wrapperFactory(context) },
+    )
+
+    expect(result.current).toBe('Foo')
+
+    index = '2'
+    rerender()
+
+    expect(result.current).toBe('Bar')
     unmount()
   })
 

--- a/packages/react/src/useStore.ts
+++ b/packages/react/src/useStore.ts
@@ -83,6 +83,7 @@ export const useStore = <Mapper extends StoreToPropMapper>(
     context: { getStore },
     synchronousUpdate,
   } = useInternalFleurContext()
+
   const referencedStores = useRef<Set<StoreClass>>(new Set())
   const isMounted = useRef<boolean>(false)
   const [, rerender] = useReducer(s => s + 1, 0)
@@ -103,15 +104,19 @@ export const useStore = <Mapper extends StoreToPropMapper>(
   )
 
   const latestState = useRef<ReturnType<Mapper> | null>(null)
+  const latestSelector = useRef<Mapper>(mapStoresToProps)
 
-  if (!latestState.current) {
+  if (!latestState.current || latestSelector.current !== mapStoresToProps) {
     latestState.current = mapStoresToProps(getStoreInspector)
+    latestSelector.current = mapStoresToProps
   }
 
   const handleStoreMutation = useCallback(() => {
     const nextState = mapStoresToProps(getStoreInspector)
+
     if (checkEquality?.(latestState.current!, nextState)) return
     latestState.current = nextState
+
     rerender()
   }, [mapStoresToProps, getStoreInspector])
 


### PR DESCRIPTION
In situation likes "select entity by query id in page" with lambda selector

```ts
// Let userId is "1" in first rendering, "2" in next rendering
const { userId } = useParams()

// Expect to return user(id: 1) in first rendering, it works correctly
// 💥WTF💥 Expect to return user(id: 2) in next rendering, but returns user(id: 1)
const user = useStore(getStore => UserSelector.byId(getStore, userId))
```