### PR TITLE
Use superjson instead of serialize-javascript

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fleur/fleur": "^2.0.0",
-    "serialize-javascript": "4.0.0"
+    "superjson": "^1.4.1"
   },
   "sideEffects": false
 }

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,7 +1,7 @@
 import { NextPageContext } from 'next'
 import { AppContext as NextAppContext } from 'next/app'
 import { AppContext } from '@fleur/fleur'
-import serialize from 'serialize-javascript'
+import superjson from 'superjson'
 
 export interface PageContext extends NextPageContext {
   executeOperation: AppContext['executeOperation']
@@ -27,9 +27,9 @@ export const bindFleurContext = (
 }
 
 export const serializeContext = (context: AppContext): string => {
-  return serialize(context.dehydrate())
+  return superjson.stringify(context.dehydrate())
 }
 
 export const deserializeContext = (state: string) => {
-  return eval(`(${state})`)
+  return superjson.parse(state)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7331,6 +7331,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -7350,7 +7355,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
+lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -9174,7 +9179,7 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   dependencies:
@@ -9956,13 +9961,6 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
-
 serialize-javascript@^1.6.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
@@ -10482,6 +10480,14 @@ stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+superjson@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.4.1.tgz#c96501fc0cc32cc9cb25ecc3fb476db631eceba2"
+  integrity sha512-+PjOQNj7mW4I0t3KphIgwwQvQObd5Tc1DtUoIMj3iN7RXQyoWr2R8LXLtQw/UNEItSd0Al+qn0I/8yCnTXiAIw==
+  dependencies:
+    lodash "^4.17.20"
+    lodash-es "^4.17.15"
 
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
## Pros (Why)

When use serialize-javascript, it must run `eval` function to deserialize a state. `eval` is dangerous and it forced to write `script-src: unsafe-eval` in Content Security Policy even though doesn't forced it in plain Next.js.
https://github.com/vercel/next.js/blob/canary/examples/with-strict-csp/pages/_document.js#L11-L13

Superjson provides deserialize function (of cource without `eval`) and supports `Set` and `Map` objects. It serves our purpose.

## Cons

Superjson's serialize function emit 2 fields `json` and `meta`, therefore serialize string tend to be longer.

## Breaking Changes

Superjson doesn't support function serialization, however serializable function must be pure function that can't use variable out of scope in the first place. In most cases no problem, but when use noop function `() => {}` for a initial state, it may cause problems.