### PR TITLE
reduce test matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10.x, 12.x, 11.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://nodejs.org/ja/about/releases/ is the current maintainanced node.js versions.
v11 and v13 is not exists.

node install postcss on v11 and v13 failed.

https://github.com/walf443/fleur/runs/1502683213?check_suite_focus=true

```
[2/4] Fetching packages...
error postcss@8.1.7: The engine "node" is incompatible with this module. Expected version "^10 || ^12 || >=14". Got "13.14.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

Installation failed.
```
